### PR TITLE
Fix error while running 'make publish'

### DIFF
--- a/pelican_comment_system/pelican_comment_system.py
+++ b/pelican_comment_system/pelican_comment_system.py
@@ -157,7 +157,7 @@ def add_static_comments(gen, content):
 
     if not os.path.isdir(folder):
         logger.debug("No comments found for: %s", content.slug)
-        write_feed(gen, [], context, content.slug)
+        #write_feed(gen, [], context, content.slug)
         return
 
     reader = Readers(gen.settings)


### PR DESCRIPTION
Was otherwise giving error:

CRITICAL: ValueError: max() arg is an empty sequence
